### PR TITLE
Upgrade aws-sam-cli version

### DIFF
--- a/python-lambda/Dockerfile
+++ b/python-lambda/Dockerfile
@@ -8,4 +8,4 @@ RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-${CC_T
     pip install -U --user pytest==5.0.1 && \
     pip install -U --user boto3==1.9.192 && \
     pip install -U --user awscli==1.16.202 && \
-    pip install -U --user aws-sam-cli==0.18.0
+    pip install -U --user aws-sam-cli==0.23.0


### PR DESCRIPTION
Event bus deploys failing with:
```
sam build
2019-10-28 20:07:09 Building resource 'Gatekeeper'
2019-10-28 20:07:09 Running PythonPipBuilder:ResolveDependencies

Build Failed
Error: PythonPipBuilder:ResolveDependencies - Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'module' object is not callable
```

Found [this github issue](https://github.com/awslabs/aws-sam-cli/issues/1461) which was fixed in `v0.23.0`.

Pulled the docker image, replicated the issue then upgraded sam and it worked:
```
(venv) circleci@c44afc19420b:/home/event-bus$ /home/event-bus/venv/bin/sam --version
SAM CLI, version 0.23.0
(venv) circleci@c44afc19420b:/home/event-bus$ /home/event-bus/venv/bin/sam build

        SAM CLI now collects telemetry to better understand customer needs.

        You can OPT OUT and disable telemetry collection by setting the
        environment variable SAM_CLI_TELEMETRY=0 in your shell.
        Thanks for your help!

        Learn More: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-telemetry.html

Building resource 'Gatekeeper'
Running PythonPipBuilder:ResolveDependencies
Running PythonPipBuilder:CopySource
Building resource 'PreTrafficLambdaFunction'
Running PythonPipBuilder:ResolveDependencies
Running PythonPipBuilder:CopySource

Build Succeeded

Built Artifacts  : .aws-sam/build
Built Template   : .aws-sam/build/template.yaml

Commands you can use next
=========================
[*] Invoke Function: sam local invoke
[*] Package: sam package --s3-bucket <yourbucket>

```
