### PR TITLE
Add dockerfile for node based on aws lambda node10.x reference container

### DIFF
--- a/node-lambda/aws-10.x/Dockerfile
+++ b/node-lambda/aws-10.x/Dockerfile
@@ -1,0 +1,40 @@
+FROM amazon/lambda-build-node10.x:latest
+LABEL maintainer "Guild Engineering <engineering@guildeducation.com>"
+
+ENV CC_TEST_REPORTER_VERSION 0.7.0
+ENV DOCKERIZE_VERSION v0.3.0
+ENV TERRAFORM_VERSION 0.12.13
+ENV AUTH0_PROVIDER_VERSION v0.2.1
+ENV PATH "$PATH:/root/.local/bin:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"
+
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-${CC_TEST_REPORTER_VERSION}-linux-amd64 > /usr/local/bin/cc-test-reporter && \
+    chmod +x /usr/local/bin/cc-test-reporter
+
+# install necessary utils not present in amazon linux
+RUN yum -y -q update && \
+    yum -y install tar zip unzip jq
+
+# install dockerize
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# install pact
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.69.0/pact-1.69.0-linux-x86_64.tar.gz && \
+    tar -C /usr/local/ -xzf pact-1.69.0-linux-x86_64.tar.gz && \
+    rm pact-1.69.0-linux-x86_64.tar.gz
+
+# install terraform with auth0
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    mkdir -m +x -p ~/.terraform.d/plugins && \
+    wget https://github.com/alexkappa/terraform-provider-auth0/releases/download/${AUTH0_PROVIDER_VERSION}/terraform-provider-auth0_${AUTH0_PROVIDER_VERSION}_linux_amd64.tar.gz && \
+    tar -C ~/.terraform.d/plugins -xzf terraform-provider-auth0_${AUTH0_PROVIDER_VERSION}_linux_amd64.tar.gz && \
+    rm terraform-provider-auth0_${AUTH0_PROVIDER_VERSION}_linux_amd64.tar.gz
+
+# install sam cli and yarn
+RUN pip install awscli --upgrade && \
+    pip install aws-sam-cli==0.33.1 && \
+    curl -o- -L https://yarnpkg.com/install.sh | bash && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In preparation for Node 8.10 being deprecated on AWS, I was looking into what we'd need in order to migrate to 10.x

I noticed that we're building our containers on top of official Node images, however these images are built with Python 2.7, which is also deprecated, and we've seen some issues with incompatibility errors and deprecation warnings during the `pip install` phase of platform-employment deploys. We are also limited to `aws-sam-cli` version 0.23.0 or lower.

Amazon provides a reference image for Node Lambda containers which is set up with Python 3.7 and behaves like their Lambda environment, which could be used both for deploying and local testing. I based this new Dockerfile on our existing node-lambda 10.16.3 Dockerfile, and made adjustments to build directly off of Amazon's reference container. This container uses amazon linux, so `apt-get` calls have been replaced with `yum`.

The latest Yarn version is also installed by default at the end of this Dockerfile, and the $PATH env is set up here, rather than needing to be remembered in Circle configs or deploy scripts.