### PR TITLE
update aws and sam versions for node-lambda:latest image

### DIFF
--- a/node-lambda/latest/Dockerfile
+++ b/node-lambda/latest/Dockerfile
@@ -29,6 +29,6 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && \
     apt-get -y install python-dev && \
-    pip install awscli==1.16.170 --upgrade --user && \
-    pip install aws-sam-cli==0.16.0 && \
+    pip install awscli==1.18.153 --upgrade --user && \
+    pip install aws-sam-cli==0.23.0 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Description
- Upgrading AWS CLI and SAM versions on the node-lambda:latest image
- In repsonse to [this failure](https://app.circleci.com/pipelines/github/GuildEducationInc/npmlibs/450/workflows/f131efec-cb15-4337-bf09-49aa1f9965dc/jobs/469) on a npmlibs circleCI build on the `aws configure` command

```
Traceback (most recent call last):
  File "/root/.local/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/root/.local/lib/python2.7/site-packages/awscli/clidriver.py", line 36, in <module>
    from awscli.help import ProviderHelpCommand
  File "/root/.local/lib/python2.7/site-packages/awscli/help.py", line 23, in <module>
    from botocore.docs.bcdoc import docevents
ImportError: cannot import name docevents
```

- This https://github.com/boto/boto3/issues/2596 suggests an aws cli upgrade is needed
- Also drawing from @spinfooser PR https://github.com/GuildEducationInc/docker-circleci-guild/pull/26

I don't see many non-archived repos using this image. Tagging all the folks that do for a ✅ :

@edbarnesG  https://github.com/GuildEducationInc/smtp-relay/blob/73d5703780d3c47b441490349c01bc3634e13470/.circleci/config.yml

@brandonecraig  https://github.com/GuildEducationInc/ups/blob/7bc655268393cad43d3025a8cba172d1bc196230/.circleci/config.yml#L82

@blakeworsley https://github.com/GuildEducationInc/component-usage-reporter/blob/19cd7559625eaebcf1cd7dc424080b9f83758e0c/.circleci/config.yml#L52
 